### PR TITLE
Detector Fix

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -19,14 +19,26 @@
  */
 var detector = module.exports;
 
+var normalize = function(path) {
+  var last = Array.prototype.pop.apply(path);
+  
+  if (process.platform !== "win32" && last !== '/') {
+    path += '/';
+  }
+  
+  return path;
+}
+
 /**
  * Returns tmp dir. Thank you npm.
  * 
  * @returns {String} tmp dir.
  */
 detector.tmp = function() {
-  return process.env.TMPDIR
+  var temp = process.env.TMPDIR
       || process.env.TMP
       || process.env.TEMP
       || (process.platform === "win32" ? "c:\\windows\\temp\\" : "/tmp/")
+  
+  return normalize(temp);
 };


### PR DESCRIPTION
OS:  openSUSE 11.4, fully patched
Node:  nodejs-0.8.9-9.1.x86_64

Current openSUSE version is 12.2, so my OS is a bit old, but even on 12.2 the latest nodejs version available is 0.8.9.

The Default TMPDIR=/tmp

Currently temporary assumes that the temp dir environment variable ends in a '/' on *nix platforms. I have added some code to ensure it. This is a problem for certain distributions of Linux using Temporary namely openSUSE.

Thanks!

Merrick
