### PR TITLE
lib/detector.js not properly normalizing pathname in Windows.

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -53,3 +53,5 @@ detector.tmp = function() {
   
   return normalize(temp);
 };
+
+detector._normalize = normalize;

--- a/test/detector.test.js
+++ b/test/detector.test.js
@@ -20,5 +20,21 @@ describe('detector', function() {
           || (process.platform === "win32" ? "c:\\windows\\temp\\" : "/tmp/");
       detector.tmp().should.eql(tmp);
     });
+    it('should normalize windows paths correctly', function () {
+      var platform_noConflict = process.platform;
+      
+      process.platform = 'win32';
+      detector._normalize('c:\\windows\\foo\\bar\\')
+          .should.eql('c:\\windows\\foo\\bar\\/');
+      detector._normalize('c:/windows/foo/bar/')
+         .should.eql('c:/windows/foo/bar//');
+      detector._normalize('c:/windows/foo/bar')
+         .should.eql('c:/windows/foo/bar/');
+      detector._normalize('c:\\windows\\foo\\bar')
+         .should.eql('c:\\windows\\foo\\bar/');
+      process.platform = platform_noConflict;
+    });
+
   });
 });
+


### PR DESCRIPTION
Hey Vesln,

We were having trouble with temporary on a windows machine that had

``` javascript
process.env.TEMP = process.env.TMP = 'C:/path/to/some/user/appdata/local/temp';
```

The detector fails to properly resolve this path (by adding a needed trailing slash) such that temporary was creating folders:
../../appdata/local/temp134545353453.5453 etc.

It is not guaranteed that windows dir paths will end in '\'.  It should also be noted that adding additional '/' to a windows path is okay because windows will correctly resolve the path anyway see stack overflow here:

http://stackoverflow.com/questions/4158597/extra-slashes-in-path-variable-of-file-copy-or-directory-createdirectory-met

Made the fix in detector.js with comments as well as some unit tests related. 

Please accept pull request.

Thanks.

sterpe 
sterpe@rubiconproject.com
