### PR TITLE
Fix for writeFile wrapper

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -55,7 +55,7 @@ File.prototype.readFileSync = function() {
  * Asynchronously writes data to a file.
  */
 File.prototype.writeFile = function() {
-  fs.writeFile.apply(fs, this.prepareArgs(arguments, ['', {}, function(err) {throw Error(err)}]));
+  fs.writeFile.apply(fs, this.prepareArgs(arguments, [{}, function(err) {throw Error(err)}]));
 };
 
 /**

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -46,7 +46,7 @@ describe('Tempfile', function() {
     it('should call fs.readfile', function() {
       sinon.spy(fs, 'writeFile');
       var tmp = new Tempfile;
-      tmp.writeFile('test.txt', {}, function() {});
+      tmp.writeFile({}, function() {});
       fs.writeFile.getCall(0).args[0].should.eql(tmp.path);
       fs.writeFile.restore();
     });


### PR DESCRIPTION
I don't know how to run tests, it just says `make: Nothing to be done for 'test'.`, but I tested it exploratorily.
Without this fix writeFile throws error on node 12.2:
```
> f.writeFile("hello world", (err) => { console.log(err) })
undefined
> Thrown:
Error: null
    at /temporary/lib/file.js:58:84
```